### PR TITLE
Prepare CFposters

### DIFF
--- a/_pages/call-for-posters.md
+++ b/_pages/call-for-posters.md
@@ -7,7 +7,7 @@ title: Call for Posters
 
 Contact: <posters@ldav.org>
 
-We invite you to submit unpublished work to the IEEE LDAV 2018 Poster Program.
+We invite you to submit unpublished work to the IEEE LDAV 2019 Poster Program.
 The poster program is a venue designed to highlight ongoing research and late breaking topics that have produced promising preliminary results. 
 The poster program will be a great opportunity 
 for the authors to interact with the symposium attendees and solicit feedback.
@@ -22,7 +22,7 @@ The format of the summary will be the same as the format used for the regular pa
 Poster authors are encouraged, but not required, to include a draft or sketch of the poster layout and content in their submission. 
 This would help reviewers and show that the poster format is used effectively. 
 The draft poster should be in PDF format. 
-The authors should indicate if the poster would be accompanied by an on-site demonstration and/or videos.
+The authors should indicate if they would like the poster to be accompanied by an on-site demonstration and/or videos. Such demo/video presentations have to be self-organized.
 
 ## Poster 2-Page Summary Submission Instructions
 
@@ -32,8 +32,8 @@ The summary should be formatted according to guidelines available on the [IEEE V
 **Submission Site:**
 Go to the [submission site](https://new.precisionconference.com/~vgtc), log in, go to 'Submissions', and select 
 * Society: 'VGTC'
-* Conference: 'LDAV 2018'
-* Track: 'LDAV 2018 Posters'.
+* Conference: 'LDAV 2019'
+* Track: 'LDAV 2019 Posters'.
 
 ## Layout and Dimensions of the Posters
 
@@ -55,10 +55,10 @@ Plagiarism in any form is unacceptable and will lead to a removal of the submiss
 ## Important Dates
 
 Two-page poster paper submission
-: August 24, 2018, 11:59 PM (AOE)
+: August 17, 2019, 11:59 PM (AOE)
 
 Author Notification:	
-: August 28, 2018
+: August 21, 2019
 
 Camera-Ready Deadline
-: September 03, 2018
+: September 28, 2019

--- a/_pages/call-for-posters.md
+++ b/_pages/call-for-posters.md
@@ -61,4 +61,4 @@ Author Notification:
 : August 21, 2019
 
 Camera-Ready Deadline
-: September 28, 2019
+: August 28, 2019

--- a/_pages/call-for-posters.md
+++ b/_pages/call-for-posters.md
@@ -1,0 +1,64 @@
+---
+layout: default
+title: Call for Posters
+---
+
+# Call for Posters
+
+Contact: <posters@ldav.org>
+
+We invite you to submit unpublished work to the IEEE LDAV 2018 Poster Program.
+The poster program is a venue designed to highlight ongoing research and late breaking topics that have produced promising preliminary results. 
+The poster program will be a great opportunity 
+for the authors to interact with the symposium attendees and solicit feedback.
+
+In addition to the topics listed under [Call for Papers](/call-for-papers.html), we also welcome submissions that
+* showcase successful stories of applying visualization to large-scale data intensive applications, and 
+* highlights of recent visualization work presented or published in another venue. 
+
+Interested authors should submit a two-page summary that describes the underlying problem, the proposed method, and preliminary results. 
+Accepted summaries will be included in the symposium proceedings. 
+The format of the summary will be the same as the format used for the regular paper submission.
+Poster authors are encouraged, but not required, to include a draft or sketch of the poster layout and content in their submission. 
+This would help reviewers and show that the poster format is used effectively. 
+The draft poster should be in PDF format. 
+The authors should indicate if the poster would be accompanied by an on-site demonstration and/or videos.
+
+## Poster 2-Page Summary Submission Instructions
+
+Submitted summaries may not exceed the maximum of two pages in length including references. 
+The summary should be formatted according to guidelines available on the [IEEE VGTC Website](http://junctionpublishing.org/vgtc/Tasks/camera.html).
+
+**Submission Site:**
+Go to the [submission site](https://new.precisionconference.com/~vgtc), log in, go to 'Submissions', and select 
+* Society: 'VGTC'
+* Conference: 'LDAV 2018'
+* Track: 'LDAV 2018 Posters'.
+
+## Layout and Dimensions of the Posters
+
+The dimensions of the posters should not exceed the A0 *portrait* space (841mm x 1189mm or 33.1" x 46.8"). 
+The poster authors can determine the layout by themselves, but please be sure to follow the dimensions described above.
+
+## Best Poster Award
+The LDAV Program Committee will award the Best Poster Award to the authors whose submission is deemed the strongest according to the reviewing criteria. 
+This award will be announced at the event.
+
+## Plagiarism
+
+All submissions must be either: 1) original work that has not been presented previously at any workshop, symposium, or conference, or published previously in any archived conference proceeding, magazine, or journal; or 2) a summary that highlights work presented or published in a related venue with a clear statement of attribution to the original work. 
+
+At the time of submission, it is required by the authors to state explicitly in the submission form that the submitted work is the work by the authors themselves, or is a summary of previously presented/published work with clear attribution. 
+Plagiarism in any form is unacceptable and will lead to a removal of the submission from the review process. For more information, please see the [IEEE plagiarism FAQ](https://www.ieee.org/publications_standards/publications/rights/plagiarism_FAQ.html) and the [IEEE Publication Services and Products Board Operations Manual](http://www.ieee.org/documents/opsmanual.pdf).
+
+
+## Important Dates
+
+Two-page poster paper submission
+: August 24, 2018, 11:59 PM (AOE)
+
+Author Notification:	
+: August 28, 2018
+
+Camera-Ready Deadline
+: September 03, 2018


### PR DESCRIPTION
This will be our CFPosters for 2019.
Please double-check for inconsistencies with the overall timeline.